### PR TITLE
Add donation link to appear on Nextcloud appstore

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -24,6 +24,7 @@ Interval for fetch may be adjusted in the admin settings "Auto Currency" section
 	<category>tools</category>
 	<website>https://github.com/chenasraf/nextcloud-autocurrency</website>
 	<bugs>https://github.com/chenasraf/nextcloud-autocurrency/issues</bugs>
+	<donation>https://ko-fi.com/casraf</donation>
 	<dependencies>
 		<nextcloud min-version="29" max-version="31"/>
 	</dependencies>


### PR DESCRIPTION
For better visibility to users (who will not visit github page)

For example of result see for example https://apps.nextcloud.com/apps/passwords (handle taken from funding.yaml and resulting URL checked against that one in github page infobox - but please recheck)